### PR TITLE
Fix dynamic island text update

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,16 +57,48 @@
       border-radius: 32px;
       font-size: 1rem;
       box-shadow: 0 4px 10px rgba(0,0,0,0.3);
-      pointer-events: none;
+      pointer-events: auto;
       z-index: 1000;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      overflow: hidden;
+      white-space: nowrap;
       transition: transform 0.5s ease, opacity 0.5s ease, background-color 0.5s ease;
-      animation: shake-uniform 0.5s linear infinite;
+      animation: shake-uniform 3s linear infinite;
+    }
+
+    #dyn-menu {
+      display: flex;
+      gap: 12px;
+      opacity: 0;
+      pointer-events: none;
+      max-width: 0;
+      overflow: hidden;
+      transition: opacity 0.3s ease, max-width 0.4s ease;
+    }
+
+    #dyn-island:hover #dyn-menu {
+      opacity: 1;
+      pointer-events: auto;
+      max-width: 320px;
+    }
+
+    #dyn-menu a {
+      color: #fff;
+      text-decoration: none;
+      font-size: 0.9rem;
+      padding: 4px 8px;
+    }
+
+    #dyn-menu a:hover {
+      text-decoration: underline;
     }
     @keyframes shake-uniform {
-      0%,100% { transform: translateX(-50%); }
-      25% { transform: translateX(calc(-50% - 2px)); }
-      50% { transform: translateX(calc(-50% + 2px)); }
-      75% { transform: translateX(calc(-50% - 2px)); }
+      0%,80%,100% { transform: translateX(-50%); }
+      83% { transform: translateX(calc(-50% - 2px)); }
+      88% { transform: translateX(calc(-50% + 2px)); }
+      93% { transform: translateX(calc(-50% - 2px)); }
     }
     @keyframes spin {
       to { transform: rotate(360deg); }
@@ -87,7 +119,14 @@
   </style>
 </head>
 <body>
-  <div id="dyn-island">Bah Lo&iuml;c-Emmanuel / Section 1</div>
+  <div id="dyn-island"><span id="dyn-text">Bah Lo&iuml;c-Emmanuel / Section 1</span>
+    <div id="dyn-menu">
+      <a href="#">Bio</a>
+      <a href="#">Parcours</a>
+      <a href="#">Passions</a>
+      <a href="#">Téléchargement</a>
+    </div>
+  </div>
   <section class="section" data-text="Présente" data-color="">Bonjour & Bienvenue </section>
 
   <section class="section" data-text="& son Parcours" data-color="">Section 2</section>
@@ -98,6 +137,7 @@
 
   <script>
     const dynIsland = document.getElementById('dyn-island');
+    const dynText = document.getElementById('dyn-text');
     const sections = document.querySelectorAll('.section');
     const options = { threshold: 0.6 };
     const observer = new IntersectionObserver((entries) => {
@@ -119,7 +159,7 @@
       const text = section.dataset.text;
       dynIsland.classList.add('shrink');
       setTimeout(() => {
-        dynIsland.textContent = `Bah Lo\u00efc-Emmanuel / ${text}`;
+        dynText.textContent = `Bah Lo\u00efc-Emmanuel / ${text}`;
         dynIsland.style.backgroundColor = '';
         dynIsland.classList.remove('shrink');
       }, 400);

--- a/portfolio.html
+++ b/portfolio.html
@@ -57,16 +57,48 @@
       border-radius: 32px;
       font-size: 1rem;
       box-shadow: 0 4px 10px rgba(0,0,0,0.3);
-      pointer-events: none;
+      pointer-events: auto;
       z-index: 1000;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      overflow: hidden;
+      white-space: nowrap;
       transition: transform 0.5s ease, opacity 0.5s ease, background-color 0.5s ease;
-      animation: shake-uniform 0.5s linear infinite;
+      animation: shake-uniform 3s linear infinite;
+    }
+
+    #dyn-menu {
+      display: flex;
+      gap: 12px;
+      opacity: 0;
+      pointer-events: none;
+      max-width: 0;
+      overflow: hidden;
+      transition: opacity 0.3s ease, max-width 0.4s ease;
+    }
+
+    #dyn-island:hover #dyn-menu {
+      opacity: 1;
+      pointer-events: auto;
+      max-width: 320px;
+    }
+
+    #dyn-menu a {
+      color: #fff;
+      text-decoration: none;
+      font-size: 0.9rem;
+      padding: 4px 8px;
+    }
+
+    #dyn-menu a:hover {
+      text-decoration: underline;
     }
     @keyframes shake-uniform {
-      0%,100% { transform: translateX(-50%); }
-      25% { transform: translateX(calc(-50% - 2px)); }
-      50% { transform: translateX(calc(-50% + 2px)); }
-      75% { transform: translateX(calc(-50% - 2px)); }
+      0%,80%,100% { transform: translateX(-50%); }
+      83% { transform: translateX(calc(-50% - 2px)); }
+      88% { transform: translateX(calc(-50% + 2px)); }
+      93% { transform: translateX(calc(-50% - 2px)); }
     }
     @keyframes spin {
       to { transform: rotate(360deg); }
@@ -87,7 +119,14 @@
   </style>
 </head>
 <body>
-  <div id="dyn-island">Bah Lo&iuml;c-Emmanuel / Section 1</div>
+  <div id="dyn-island"><span id="dyn-text">Bah Lo&iuml;c-Emmanuel / Section 1</span>
+    <div id="dyn-menu">
+      <a href="#">Bio</a>
+      <a href="#">Parcours</a>
+      <a href="#">Passions</a>
+      <a href="#">Téléchargement</a>
+    </div>
+  </div>
   <section class="section" data-text="Présente" data-color="">Bonjour & Bienvenue </section>
 
   <section class="section" data-text="& son Parcours" data-color="">Section 2</section>
@@ -98,6 +137,7 @@
 
   <script>
     const dynIsland = document.getElementById('dyn-island');
+    const dynText = document.getElementById('dyn-text');
     const sections = document.querySelectorAll('.section');
     const options = { threshold: 0.6 };
     const observer = new IntersectionObserver((entries) => {
@@ -119,7 +159,7 @@
       const text = section.dataset.text;
       dynIsland.classList.add('shrink');
       setTimeout(() => {
-        dynIsland.textContent = `Bah Lo\u00efc-Emmanuel / ${text}`;
+        dynText.textContent = `Bah Lo\u00efc-Emmanuel / ${text}`;
         dynIsland.style.backgroundColor = '';
         dynIsland.classList.remove('shrink');
       }, 400);


### PR DESCRIPTION
## Summary
- preserve submenu markup when updating dynamic island text
- target a new `#dyn-text` span for script updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68443b246d448329bb75e975e5c11688